### PR TITLE
Separate build and sign tx actions + some tweaks

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
 import { ProjectLogo, TextButton } from "@stellar/design-system";
 
 import { ReactComponent as IconCopy } from "assets/svg/icon-copy.svg";
@@ -105,6 +106,7 @@ const CopyPublicKeyButtonEl = styled.div`
 
 export const Header = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { account } = useRedux("account");
   const { isAuthenticated } = account;
 
@@ -112,6 +114,9 @@ export const Header = () => {
     dispatch(stopAccountWatcherAction());
     dispatch(stopTxHistoryWatcherAction());
     dispatch(resetStoreAction());
+    history.push({
+      pathname: "/",
+    });
   };
 
   return (

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,14 +1,26 @@
-import { Route, Redirect, RouteProps } from "react-router-dom";
+import { Route, Redirect, RouteProps, useLocation } from "react-router-dom";
 import { useRedux } from "hooks/useRedux";
 
 export const PrivateRoute = ({ children, ...rest }: RouteProps) => {
   const { account } = useRedux("account");
   const { isAuthenticated } = account;
+  const location = useLocation();
 
   return (
     <Route
       {...rest}
-      render={() => (isAuthenticated ? children : <Redirect to="/" />)}
+      render={() =>
+        isAuthenticated ? (
+          children
+        ) : (
+          <Redirect
+            to={{
+              pathname: "/",
+              search: location.search,
+            }}
+          />
+        )
+      }
     />
   );
 };

--- a/src/components/SendTransaction/ConfirmTransaction.tsx
+++ b/src/components/SendTransaction/ConfirmTransaction.tsx
@@ -17,7 +17,6 @@ import { FONT_WEIGHT, PALETTE } from "constants/styles";
 
 import { getMemoTypeText } from "helpers/getMemoTypeText";
 import { logEvent } from "helpers/tracking";
-import { stroopsFromLumens } from "helpers/stroopConversion";
 import { sendTxAction } from "ducks/sendTx";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, AuthType, PaymentFormData } from "types/types.d";
@@ -112,12 +111,7 @@ export const ConfirmTransaction = ({
   onFailedTx,
   onBack,
 }: ConfirmTransactionProps) => {
-  const { sendTx, account, settings } = useRedux(
-    "sendTx",
-    "keyStore",
-    "account",
-    "settings",
-  );
+  const { sendTx, settings } = useRedux("sendTx", "keyStore", "settings");
   const { status, errorString } = sendTx;
   const dispatch = useDispatch();
 
@@ -140,25 +134,12 @@ export const ConfirmTransaction = ({
   }, [status, onSuccessfulTx, onFailedTx, errorString]);
 
   const handleSend = () => {
-    if (account.data) {
-      dispatch(
-        sendTxAction({
-          publicKey: account.data.id,
-          // formData.federationAddress exists only if valid fed address given
-          toAccountId: formData.federationAddress || formData.toAccountId,
-          amount: formData.amount,
-          fee: stroopsFromLumens(maxFee).toNumber(),
-          memoType: formData.memoType,
-          memoContent: formData.memoContent,
-          isAccountFunded: formData.isAccountFunded,
-        }),
-      );
-      logEvent("send: confirmed transaction", {
-        amount: formData.amount.toString(),
-        "used federation address": !!formData.federationAddress,
-        "used memo": !!formData.memoContent,
-      });
-    }
+    dispatch(sendTxAction(formData.tx));
+    logEvent("send: confirmed transaction", {
+      amount: formData.amount.toString(),
+      "used federation address": !!formData.federationAddress,
+      "used memo": !!formData.memoContent,
+    });
   };
 
   const getInstructionsMessage = (type: AuthType) => {

--- a/src/components/SendTransaction/SendTransactionFlow.tsx
+++ b/src/components/SendTransaction/SendTransactionFlow.tsx
@@ -26,6 +26,7 @@ const initialFormData: PaymentFormData = {
   memoContent: "",
   isAccountFunded: true,
   isAccountUnsafe: false,
+  tx: undefined,
 };
 
 export const SendTransactionFlow = ({ onCancel }: { onCancel: () => void }) => {

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -138,6 +138,7 @@ const TableEl = styled.table`
     td {
       padding-top: 1.5rem;
       padding-bottom: 1.5rem;
+      word-break: break-word;
     }
 
     th:nth-of-type(3),

--- a/src/ducks/sendTx.ts
+++ b/src/ducks/sendTx.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { MemoType, MemoValue, Horizon } from "stellar-sdk";
+import { MemoType, MemoValue, Horizon, Transaction } from "stellar-sdk";
 import { getErrorString } from "helpers/getErrorString";
 import { submitPaymentTransaction } from "helpers/submitPaymentTransaction";
 import { ActionStatus, SendTxInitialState, RejectMessage } from "types/types.d";
@@ -17,12 +17,12 @@ export interface PaymentTransactionParams {
 
 export const sendTxAction = createAsyncThunk<
   Horizon.TransactionResponse,
-  PaymentTransactionParams,
+  Transaction | any,
   { rejectValue: RejectMessage; state: RootState }
->("sendTx/sendTxAction", async (params, { rejectWithValue }) => {
+>("sendTx/sendTxAction", async (tx, { rejectWithValue }) => {
   let result;
   try {
-    result = await submitPaymentTransaction(params);
+    result = await submitPaymentTransaction(tx);
   } catch (error) {
     return rejectWithValue({
       errorString: getErrorString(error),

--- a/src/helpers/buildPaymentTransaction.ts
+++ b/src/helpers/buildPaymentTransaction.ts
@@ -1,0 +1,75 @@
+import StellarSdk, { MemoType, MemoValue } from "stellar-sdk";
+import { PaymentTransactionParams } from "ducks/sendTx";
+import { getErrorString } from "helpers/getErrorString";
+import { getNetworkConfig } from "helpers/getNetworkConfig";
+import { store } from "config/store";
+
+const createMemo = (memoType: MemoType, memoContent: MemoValue) => {
+  switch (memoType) {
+    case StellarSdk.MemoText:
+      return StellarSdk.Memo.text(memoContent);
+    case StellarSdk.MemoID:
+      return StellarSdk.Memo.id(memoContent);
+    case StellarSdk.MemoHash:
+      return StellarSdk.Memo.hash(memoContent);
+    case StellarSdk.MemoReturn:
+      return StellarSdk.Memo.return(memoContent);
+    case StellarSdk.MemoNone:
+    default:
+      return StellarSdk.Memo.none();
+  }
+};
+
+export const buildPaymentTransaction = async (
+  params: PaymentTransactionParams,
+) => {
+  let transaction;
+  try {
+    const {
+      publicKey,
+      amount,
+      fee,
+      toAccountId,
+      memoContent,
+      memoType,
+      isAccountFunded,
+    } = params;
+    const { settings } = store.getState();
+    const server = new StellarSdk.Server(
+      getNetworkConfig(settings.isTestnet).url,
+    );
+    const sequence = (await server.loadAccount(publicKey)).sequence;
+    const source = await new StellarSdk.Account(publicKey, sequence);
+    let operation;
+
+    if (isAccountFunded) {
+      operation = StellarSdk.Operation.payment({
+        destination: toAccountId,
+        asset: StellarSdk.Asset.native(),
+        amount: amount.toString(),
+      });
+    } else {
+      operation = StellarSdk.Operation.createAccount({
+        destination: toAccountId,
+        startingBalance: amount.toString(),
+      });
+    }
+
+    transaction = new StellarSdk.TransactionBuilder(source, {
+      fee,
+      networkPassphrase: getNetworkConfig(settings.isTestnet).network,
+      timebounds: await server.fetchTimebounds(100),
+    }).addOperation(operation);
+
+    if (memoType !== StellarSdk.MemoNone) {
+      transaction = transaction.addMemo(createMemo(memoType, memoContent));
+    }
+
+    transaction = transaction.build();
+  } catch (error) {
+    throw new Error(
+      `Failed to build transaction, error: ${getErrorString(error)})}`,
+    );
+  }
+  return transaction;
+};

--- a/src/helpers/submitPaymentTransaction.ts
+++ b/src/helpers/submitPaymentTransaction.ts
@@ -1,104 +1,27 @@
-import StellarSdk, { MemoType, MemoValue } from "stellar-sdk";
-import { PaymentTransactionParams } from "ducks/sendTx";
+import StellarSdk, { Transaction } from "stellar-sdk";
 import { getErrorString } from "helpers/getErrorString";
 import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { store } from "config/store";
 import { signTransaction } from "helpers/keyManager";
 
-export const submitPaymentTransaction = async (
-  params: PaymentTransactionParams,
-) => {
+export const submitPaymentTransaction = async (transaction: Transaction) => {
   const { settings, keyStore } = store.getState();
   const server = new StellarSdk.Server(
     getNetworkConfig(settings.isTestnet).url,
   );
 
-  let transaction = await buildPaymentTransaction(params);
-
-  // Sign transaction
   try {
-    transaction = await signTransaction({
+    const signedTransaction = await signTransaction({
       id: keyStore.keyStoreId,
       password: keyStore.password,
       transaction,
       custom: keyStore.custom,
     });
+
+    return await server.submitTransaction(signedTransaction);
   } catch (error) {
     throw new Error(
       `Failed to sign transaction, error: ${getErrorString(error)}`,
     );
   }
-
-  const result = await server.submitTransaction(transaction);
-  return result;
-};
-
-const createMemo = (memoType: MemoType, memoContent: MemoValue) => {
-  switch (memoType) {
-    case StellarSdk.MemoText:
-      return StellarSdk.Memo.text(memoContent);
-    case StellarSdk.MemoID:
-      return StellarSdk.Memo.id(memoContent);
-    case StellarSdk.MemoHash:
-      return StellarSdk.Memo.hash(memoContent);
-    case StellarSdk.MemoReturn:
-      return StellarSdk.Memo.return(memoContent);
-    case StellarSdk.MemoNone:
-    default:
-      return StellarSdk.Memo.none();
-  }
-};
-
-export const buildPaymentTransaction = async (
-  params: PaymentTransactionParams,
-) => {
-  let transaction;
-  try {
-    const {
-      publicKey,
-      amount,
-      fee,
-      toAccountId,
-      memoContent,
-      memoType,
-      isAccountFunded,
-    } = params;
-    const { settings } = store.getState();
-    const server = new StellarSdk.Server(
-      getNetworkConfig(settings.isTestnet).url,
-    );
-    const sequence = (await server.loadAccount(publicKey)).sequence;
-    const source = await new StellarSdk.Account(publicKey, sequence);
-    let operation;
-
-    if (isAccountFunded) {
-      operation = StellarSdk.Operation.payment({
-        destination: toAccountId,
-        asset: StellarSdk.Asset.native(),
-        amount: amount.toString(),
-      });
-    } else {
-      operation = StellarSdk.Operation.createAccount({
-        destination: toAccountId,
-        startingBalance: amount.toString(),
-      });
-    }
-
-    transaction = new StellarSdk.TransactionBuilder(source, {
-      fee,
-      networkPassphrase: getNetworkConfig(settings.isTestnet).network,
-      timebounds: await server.fetchTimebounds(100),
-    }).addOperation(operation);
-
-    if (memoType !== StellarSdk.MemoNone) {
-      transaction = transaction.addMemo(createMemo(memoType, memoContent));
-    }
-
-    transaction = transaction.build();
-  } catch (error) {
-    throw new Error(
-      `Failed to build transaction, error: ${getErrorString(error)})}`,
-    );
-  }
-  return transaction;
 };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { MemoType, MemoValue, Horizon } from "stellar-sdk";
+import { MemoType, MemoValue, Horizon, Transaction } from "stellar-sdk";
 import { Types } from "@stellar/wallet-sdk";
 
 declare global {
@@ -155,4 +155,5 @@ export interface PaymentFormData {
   memoContent: MemoValue;
   isAccountFunded: boolean;
   isAccountUnsafe: boolean;
+  tx: Transaction | undefined;
 }


### PR DESCRIPTION
We used to handle build and sign transactions in the same function, which was triggered on Submit. The problem is that in this case popups (as in the Albedo case) could be blocked in the browser (this was happening only in Safari at the moment). The action which triggers the popup is preceded by another async action (build transaction) breaking the "direct" flow and making it look suspicious to the browser.

We're building the transaction beforehand now (when the user clicks Continue), so it is already prepared on the Confirmation page. Now, on Submit we call the sign action passing the transaction directly. This seems to work fine now. 🤞 

Tweaks:
- Fix Payments History layout with very long words (Memo, for example).
- Persist URL query params on refresh.
- Clear URL query params when signing out (needed because of persisting fix).