### PR TITLE
Add sign tx Ledger and Trezor helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/redux": "^3.6.0",
     "@types/styled-components": "^5.1.10",
-    "@types/trezor-connect": "^8.1.18",
     "concurrently": "^6.2.0",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/components/SignIn/SignInTrezorForm.tsx
+++ b/src/components/SignIn/SignInTrezorForm.tsx
@@ -71,7 +71,7 @@ export const SignInTrezorForm = ({ onClose }: ModalPageProps) => {
           storeKeyAction({
             publicKey: trezorData.publicKey,
             keyType: KeyType.trezor,
-            custom: trezorManifest,
+            custom: { ...trezorManifest, bipPath },
           }),
         );
         logEvent("login: connected with trezor");
@@ -89,6 +89,7 @@ export const SignInTrezorForm = ({ onClose }: ModalPageProps) => {
     setErrorMessage,
     trezorErrorMessage,
     trezorManifest,
+    bipPath,
   ]);
 
   useEffect(() => {

--- a/src/helpers/signLedgerTransaction.ts
+++ b/src/helpers/signLedgerTransaction.ts
@@ -1,0 +1,30 @@
+import StellarSdk, { Transaction } from "stellar-sdk";
+import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import LedgerApi from "@ledgerhq/hw-app-str";
+import { loadPrivateKey } from "helpers/keyManager";
+
+export const signLedgerTransaction = async (
+  transaction: Transaction,
+  keyStore: any,
+) => {
+  const key = await loadPrivateKey({
+    id: keyStore.keyStoreId,
+    password: keyStore.password,
+  });
+
+  const transport = await TransportWebUSB.create();
+  const ledgerApi = new LedgerApi(transport);
+  const result = await ledgerApi.signTransaction(
+    key.path,
+    transaction.signatureBase(),
+  );
+
+  const keyPair = StellarSdk.Keypair.fromPublicKey(key.publicKey);
+  const decoratedSignature = new StellarSdk.xdr.DecoratedSignature({
+    hint: keyPair.signatureHint(),
+    signature: result.signature,
+  });
+  transaction.signatures.push(decoratedSignature);
+
+  return Promise.resolve(transaction);
+};

--- a/src/helpers/signLedgerTransaction.ts
+++ b/src/helpers/signLedgerTransaction.ts
@@ -26,5 +26,5 @@ export const signLedgerTransaction = async (
   });
   transaction.signatures.push(decoratedSignature);
 
-  return Promise.resolve(transaction);
+  return transaction;
 };

--- a/src/helpers/signTrezorTransaction.ts
+++ b/src/helpers/signTrezorTransaction.ts
@@ -1,0 +1,45 @@
+import TrezorConnect from "trezor-connect";
+import { Transaction } from "stellar-sdk";
+import { loadPrivateKey } from "helpers/keyManager";
+import { transformTransaction } from "helpers/trezorTransformTransaction";
+
+export const signTrezorTransaction = async (
+  transaction: Transaction,
+  keyStore: any,
+) => {
+  const { keyStoreId, password, custom } = keyStore;
+
+  if (!custom || !custom.email || !custom.appUrl) {
+    throw new Error(
+      `Trezor Connect manifest with "email" and "appUrl" props is required.
+      Make sure they are passed through "custom" prop.`,
+    );
+  }
+
+  const key = await loadPrivateKey({
+    id: keyStoreId,
+    password,
+  });
+
+  TrezorConnect.manifest({
+    email: custom.email,
+    appUrl: custom.appUrl,
+  });
+
+  const bipPath = custom.bipPath || "44'/148'/0'";
+  const trezorParams = transformTransaction(`m/${bipPath}`, transaction);
+  const response = await TrezorConnect.stellarSignTransaction(trezorParams);
+
+  if (response.success) {
+    const signature = Buffer.from(response.payload.signature, "hex").toString(
+      "base64",
+    );
+    transaction.addSignature(key.publicKey, signature);
+
+    return transaction;
+  }
+
+  throw new Error(
+    response.payload?.error || "We couldn’t sign the transaction with Trezor.",
+  );
+};

--- a/src/helpers/trezorTransformTransaction.ts
+++ b/src/helpers/trezorTransformTransaction.ts
@@ -1,0 +1,203 @@
+// https://github.com/trezor/connect/blob/develop/src/js/plugins/stellar/plugin.js
+import StellarSdk, { MemoType, MemoValue, Asset } from "stellar-sdk";
+import BigNumber from "bignumber.js";
+
+/**
+ * Transforms StellarSdk.Signer to TrezorConnect.StellarTransaction.Signer
+ */
+const transformSigner = (signer: {
+  ed25519PublicKey?: string;
+  sha256Hash?: string | Buffer;
+  preAuthTx?: string | Buffer;
+  weight?: number | string;
+}) => {
+  let type = 0;
+  let key: any;
+  const { weight } = signer;
+  if (typeof signer.ed25519PublicKey === "string") {
+    const keyPair = StellarSdk.Keypair.fromPublicKey(signer.ed25519PublicKey);
+    key = keyPair.rawPublicKey().toString("hex");
+  }
+  if (signer.preAuthTx instanceof Buffer) {
+    type = 1;
+    key = signer.preAuthTx.toString("hex");
+  }
+  if (signer.sha256Hash instanceof Buffer) {
+    type = 2;
+    key = signer.sha256Hash.toString("hex");
+  }
+  return {
+    type,
+    key,
+    weight,
+  };
+};
+
+/**
+ * Transforms StellarSdk.Asset to TrezorConnect.StellarTransaction.Asset
+ */
+const transformAsset = (asset: Asset) => {
+  if (asset.isNative()) {
+    return {
+      type: 0,
+      code: asset.getCode(),
+    };
+  }
+  return {
+    type: asset.getAssetType() === "credit_alphanum4" ? 1 : 2,
+    code: asset.getCode(),
+    issuer: asset.getIssuer(),
+  };
+};
+
+/**
+ * Transforms amount from decimals (lumens) to integer (stroop)
+ */
+const transformAmount = (amount: string) =>
+  new BigNumber(amount).times(10000000).toString();
+
+/**
+ * Transforms StellarSdk.Operation.type to TrezorConnect.StellarTransaction
+ * Operation.type
+ */
+const transformType = (type: string) => {
+  switch (type) {
+    case "pathPaymentStrictReceive":
+      // case 'pathPaymentStrictSend':
+      return "pathPayment";
+
+    case "createPassiveSellOffer":
+      return "createPassiveOffer";
+
+    case "manageSellOffer":
+      // case 'manageBuyOffer':
+      return "manageOffer";
+    default:
+      return type;
+  }
+};
+
+const transformMemo = (memo: { type: MemoType; value: MemoValue }) => {
+  switch (memo.type) {
+    case StellarSdk.MemoText:
+      return StellarSdk.Memo.text(memo.value);
+    case StellarSdk.MemoID:
+      return StellarSdk.Memo.id(memo.value);
+    case StellarSdk.MemoHash:
+      return StellarSdk.Memo.hash(memo.value);
+    case StellarSdk.MemoReturn:
+      return StellarSdk.Memo.return(memo.value);
+    default:
+      return StellarSdk.Memo.none();
+  }
+};
+
+/**
+ * Transforms StellarSdk.Transaction.timeBounds to
+ * TrezorConnect.StellarTransaction.timebounds
+ */
+const transformTimebounds = (
+  timebounds:
+    | {
+        minTime: string;
+        maxTime: string;
+      }
+    | undefined,
+) => {
+  if (!timebounds) return undefined;
+  // those values are defined in Trezor firmware messages as numbers
+  return {
+    minTime: Number.parseInt(timebounds.minTime, 10),
+    maxTime: Number.parseInt(timebounds.maxTime, 10),
+  };
+};
+
+/**
+ * Transforms StellarSdk.Transaction to TrezorConnect.StellarTransaction
+ */
+export const transformTransaction = (path: string, transaction: any) => {
+  const amounts = [
+    "amount",
+    "sendMax",
+    "destAmount",
+    "startingBalance",
+    "limit",
+  ];
+  const assets = [
+    "asset",
+    "sendAsset",
+    "destAsset",
+    "selling",
+    "buying",
+    "line",
+  ];
+
+  const operations = transaction.operations.map((o: any, i: number) => {
+    const operation = { ...o };
+
+    // transform StellarSdk.Signer
+    if (operation.signer) {
+      operation.signer = transformSigner(operation.signer);
+    }
+
+    // transform asset path
+    if (operation.path) {
+      operation.path = operation.path.map(transformAsset);
+    }
+
+    // transform "price" field to { n: number, d: number }
+    if (typeof operation.price === "string") {
+      const xdrOperation = transaction.tx.operations()[i];
+      operation.price = {
+        n: xdrOperation.body().value().price().n(),
+        d: xdrOperation.body().value().price().d(),
+      };
+    }
+
+    // transform amounts
+    amounts.forEach((field) => {
+      if (typeof operation[field] === "string") {
+        operation[field] = transformAmount(operation[field]);
+      }
+    });
+
+    // transform assets
+    assets.forEach((field) => {
+      if (operation[field]) {
+        operation[field] = transformAsset(operation[field]);
+      }
+    });
+
+    // add missing field
+    if (operation.type === "allowTrust") {
+      const allowTrustAsset = new StellarSdk.Asset(
+        operation.assetCode,
+        operation.trustor,
+      );
+      operation.assetType = transformAsset(allowTrustAsset).type;
+    }
+
+    if (operation.type === "manageData" && operation.value) {
+      // stringify is not necessary, Buffer is also accepted
+      operation.value = operation.value.toString("hex");
+    }
+
+    // transform type
+    operation.type = transformType(o.type);
+
+    return operation;
+  });
+
+  return {
+    path,
+    networkPassphrase: transaction.networkPassphrase,
+    transaction: {
+      source: transaction.source,
+      fee: Number(transaction.fee),
+      sequence: transaction.sequence,
+      memo: transformMemo(transaction.memo),
+      timebounds: transformTimebounds(transaction.timeBounds),
+      operations,
+    },
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,13 +2186,6 @@
   dependencies:
     "@types/jest" "*"
 
-"@types/trezor-connect@^8.1.18":
-  version "8.1.18"
-  resolved "https://registry.yarnpkg.com/@types/trezor-connect/-/trezor-connect-8.1.18.tgz#f9758bc38c6867e1be2775de67503b5191f97823"
-  integrity sha512-S9xOlvUXc3rfLI4hwm5lVWHX0C1ts3VNHT3N7oemKH7XeQ14sOiXPn9sWAb1P3sIIEybhCFl+trLO8izGaMatw==
-  dependencies:
-    trezor-connect "*"
-
 "@types/uglify-js@*":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.12.0.tgz#2bb061c269441620d46b946350c8f16d52ef37c5"
@@ -12380,19 +12373,19 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trezor-connect@*, trezor-connect@^8.1.27:
-  version "8.1.27"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.27.tgz#7e45839d26e4c859a3ddd69213e8c7f00ba5525e"
-  integrity sha512-U6vP8kehQ5enCTY0k01R6jR3EORC+GIzTl4pM80lu9gJB5e988sM5YwK1hED6KZx7LJvFjWuOxB2J3W0pwv7lw==
+trezor-connect@^8.1.16:
+  version "8.1.22"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.22.tgz#a6b713c621fb9a108827a2b51253dd6baf05a7a1"
+  integrity sha512-majbYoNlUqNG6AncdXiOdyF02SS73rWkel1of4qHK1T1bNp92cIq8yZMoWXxil3p2b45qs5PA8pK1TBexZCQ9g==
   dependencies:
     "@babel/runtime" "^7.12.5"
     events "^3.2.0"
     whatwg-fetch "^3.5.0"
 
-trezor-connect@^8.1.16:
-  version "8.1.22"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.22.tgz#a6b713c621fb9a108827a2b51253dd6baf05a7a1"
-  integrity sha512-majbYoNlUqNG6AncdXiOdyF02SS73rWkel1of4qHK1T1bNp92cIq8yZMoWXxil3p2b45qs5PA8pK1TBexZCQ9g==
+trezor-connect@^8.1.27:
+  version "8.1.27"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.27.tgz#7e45839d26e4c859a3ddd69213e8c7f00ba5525e"
+  integrity sha512-U6vP8kehQ5enCTY0k01R6jR3EORC+GIzTl4pM80lu9gJB5e988sM5YwK1hED6KZx7LJvFjWuOxB2J3W0pwv7lw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     events "^3.2.0"


### PR DESCRIPTION
- Support custom BIP path to sign transactions with Trezor.
- Move sign transaction with Ledger to helpers.
- Use a local helper to sign a transaction with Trezor instead of using `@stellar/wallet-sdk` (this could be temporary). It's easier to keep these in sync locally when Trezor Connect is updated.
- Removed `@types/trezor-connect` because it's no longer needed.