### PR TITLE
Dark mode: wallet modals updated

### DIFF
--- a/src/components/CopyWithTooltip/index.tsx
+++ b/src/components/CopyWithTooltip/index.tsx
@@ -50,7 +50,7 @@ export const CopyWithTooltip: React.FC<CopyWithTooltipProps> &
         {children}
       </CopyToClipboard>
       <div
-        className={`CopyWithTooltip__tooltip CopyWithTooltip__tooltip--${tooltipPosition}`}
+        className={`Tooltip CopyWithTooltip__tooltip CopyWithTooltip__tooltip--${tooltipPosition}`}
         style={customStyle}
       >
         {tooltipLabel}

--- a/src/components/CopyWithTooltip/styles.scss
+++ b/src/components/CopyWithTooltip/styles.scss
@@ -6,19 +6,10 @@
 
   &__tooltip {
     visibility: var(--CopyWithTooltip-visibility);
-    padding: 0.5rem 1rem;
     // TODO: hard coded color
     background-color: #292d3e;
-    position: absolute;
     top: 2.7rem;
     right: -1rem;
-    max-width: 16.875rem;
-    border-radius: 0.125rem;
-    color: var(--pal-brand-primary-on);
-    font-size: var(--font-size-secondary);
-    line-height: 1.5em;
-    z-index: var(--z-index-tooltip);
-    cursor: default;
 
     &--bottom {
       right: 50%;

--- a/src/components/InfoButtonWithTooltip/index.tsx
+++ b/src/components/InfoButtonWithTooltip/index.tsx
@@ -1,37 +1,14 @@
-import React, { useState, useEffect, useRef } from "react";
-import styled from "styled-components";
-import { PALETTE, tooltipStyle } from "constants/styles";
-import { ReactComponent as InfoIcon } from "assets/svg/icon-info.svg";
+import React, { useRef, useEffect, useState } from "react";
+import { IconButton, Icon } from "@stellar/design-system";
+import "./styles.scss";
 
-const InfoButtonEl = styled.div`
-  cursor: pointer;
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-left: 0.875rem;
-
-  svg {
-    width: 100%;
-    height: 100%;
-    fill: ${PALETTE.grey};
-  }
-`;
-
-const InfoEl = styled.div<{ isVisible: boolean }>`
-  ${tooltipStyle};
-  visibility: ${(props) => (props.isVisible ? "visible" : "hidden")};
-
-  a {
-    color: inherit;
-    white-space: nowrap;
-  }
-`;
-
-export const InfoButtonWithTooltip = ({
-  children,
-}: {
+interface InfoButtonWithTooltipProps {
   children: string | React.ReactNode;
+}
+
+export const InfoButtonWithTooltip: React.FC<InfoButtonWithTooltipProps> = ({
+  children,
 }) => {
-  const toggleEl = useRef<null | HTMLDivElement>(null);
   const infoEl = useRef<null | HTMLDivElement>(null);
   const [isInfoVisible, setIsInfoVisible] = useState(false);
 
@@ -56,27 +33,33 @@ export const InfoButtonWithTooltip = ({
       return;
     }
 
-    if (!toggleEl?.current?.contains(event.target as Node)) {
+    const parent = infoEl?.current?.closest(".WalletButton");
+
+    if (!parent?.contains(event.target as Node)) {
       setIsInfoVisible(false);
     }
   };
 
+  const customStyle = {
+    "--InfoButtonWithTooltip-visibility": isInfoVisible ? "visible" : "hidden",
+  } as React.CSSProperties;
+
   return (
     <>
-      <InfoButtonEl
-        ref={toggleEl}
+      <IconButton
+        icon={<Icon.Info />}
+        altText="View more information"
         onClick={() => setIsInfoVisible((currentState) => !currentState)}
-      >
-        <InfoIcon />
-      </InfoButtonEl>
+      />
 
-      <InfoEl
+      <div
+        className="Tooltip InfoButtonWithTooltip__tooltip"
+        style={customStyle}
         ref={infoEl}
         data-hidden={!isInfoVisible}
-        isVisible={isInfoVisible}
       >
         {children}
-      </InfoEl>
+      </div>
     </>
   );
 };

--- a/src/components/InfoButtonWithTooltip/styles.scss
+++ b/src/components/InfoButtonWithTooltip/styles.scss
@@ -1,0 +1,11 @@
+.InfoButtonWithTooltip {
+  &__tooltip {
+    --InfoButtonWithTooltip-visibility: "hidden";
+
+    visibility: var(--InfoButtonWithTooltip-visibility);
+    top: 2.7rem;
+    right: -0.5rem;
+    // TODO: handle specificity from main styles.scss
+    padding: 1rem 1.5rem !important;
+  }
+}

--- a/src/components/SignIn/SignInAlbedoForm.tsx
+++ b/src/components/SignIn/SignInAlbedoForm.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 import { Button, InfoBlock } from "@stellar/design-system";
 import { KeyType } from "@stellar/wallet-sdk";
 
-import { ModalWalletContent } from "components/ModalWalletContent";
+import { WalletModalContent } from "components/WalletModalContent";
 import { ErrorMessage } from "components/ErrorMessage";
 
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
@@ -91,7 +91,7 @@ export const SignInAlbedoForm = ({ onClose }: ModalPageProps) => {
   ]);
 
   return (
-    <ModalWalletContent
+    <WalletModalContent
       type="albedo"
       buttonFooter={
         <>
@@ -117,6 +117,6 @@ export const SignInAlbedoForm = ({ onClose }: ModalPageProps) => {
       )}
 
       <ErrorMessage message={errorMessage} textAlign="center" />
-    </ModalWalletContent>
+    </WalletModalContent>
   );
 };

--- a/src/components/SignIn/SignInFreighterForm.tsx
+++ b/src/components/SignIn/SignInFreighterForm.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from "react-redux";
 import { Button, InfoBlock } from "@stellar/design-system";
 import { KeyType } from "@stellar/wallet-sdk";
 
-import { ModalWalletContent } from "components/ModalWalletContent";
+import { WalletModalContent } from "components/WalletModalContent";
 import { ErrorMessage } from "components/ErrorMessage";
 
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
@@ -103,7 +103,7 @@ export const SignInFreighterForm = ({ onClose }: ModalPageProps) => {
     : "To use Freighter, please download or enable Freighter browser extension wallet.";
 
   return (
-    <ModalWalletContent
+    <WalletModalContent
       type="freighter"
       buttonFooter={
         <>
@@ -131,6 +131,6 @@ export const SignInFreighterForm = ({ onClose }: ModalPageProps) => {
         textAlign="center"
         marginTop="1rem"
       />
-    </ModalWalletContent>
+    </WalletModalContent>
   );
 };

--- a/src/components/SignIn/SignInLedgerForm.tsx
+++ b/src/components/SignIn/SignInLedgerForm.tsx
@@ -8,7 +8,7 @@ import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
 
 import { BipPathInput } from "components/BipPathInput";
 import { ErrorMessage } from "components/ErrorMessage";
-import { ModalWalletContent } from "components/ModalWalletContent";
+import { WalletModalContent } from "components/WalletModalContent";
 
 import { defaultStellarBipPath } from "constants/settings";
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
@@ -120,7 +120,7 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
   };
 
   return (
-    <ModalWalletContent
+    <WalletModalContent
       type="ledger"
       buttonFooter={
         <>
@@ -180,6 +180,6 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
         value={ledgerBipPath}
         onValueChange={(val) => setLedgerBipPath(val)}
       />
-    </ModalWalletContent>
+    </WalletModalContent>
   );
 };

--- a/src/components/SignIn/SignInTrezorForm.tsx
+++ b/src/components/SignIn/SignInTrezorForm.tsx
@@ -7,7 +7,7 @@ import { KeyType } from "@stellar/wallet-sdk";
 
 import { BipPathInput } from "components/BipPathInput";
 import { ErrorMessage } from "components/ErrorMessage";
-import { ModalWalletContent } from "components/ModalWalletContent";
+import { WalletModalContent } from "components/WalletModalContent";
 
 import { defaultStellarBipPath } from "constants/settings";
 import { fetchAccountAction, resetAccountAction } from "ducks/account";
@@ -117,7 +117,7 @@ export const SignInTrezorForm = ({ onClose }: ModalPageProps) => {
   ]);
 
   return (
-    <ModalWalletContent
+    <WalletModalContent
       type="trezor"
       buttonFooter={
         <>
@@ -148,6 +148,6 @@ export const SignInTrezorForm = ({ onClose }: ModalPageProps) => {
         value={bipPath}
         onValueChange={(val) => setBipPath(val)}
       />
-    </ModalWalletContent>
+    </WalletModalContent>
   );
 };

--- a/src/components/WalletButton/index.tsx
+++ b/src/components/WalletButton/index.tsx
@@ -19,9 +19,9 @@ export const WalletButton: React.FC<WalletButtonProps> = ({
   ...props
 }) => (
   <div className="WalletButton">
-    <button onClick={onClick} {...props}>
+    <button className="WalletButton__button" onClick={onClick} {...props}>
       {renderSvg({ Component: imageSvg, alt: imageAlt })}
-      <span>{children}</span>
+      <span className="WalletButton__label">{children}</span>
     </button>
 
     <InfoButtonWithTooltip>{infoText}</InfoButtonWithTooltip>

--- a/src/components/WalletButton/styles.scss
+++ b/src/components/WalletButton/styles.scss
@@ -5,17 +5,25 @@
   position: relative;
   min-width: 250px;
 
-  button {
+  &__button {
     flex: 1;
     border: 1px solid var(--pal-border-primary);
     border-radius: 0.25rem;
     background-color: var(--pal-background-primary);
     padding: 0.75rem;
+    margin-right: 0.875rem;
     display: flex;
     flex-direction: row;
     justify-content: center;
     align-items: center;
     cursor: pointer;
+    transition: border-color var(--anim-transition-default);
+
+    @media (hover: hover) {
+      &:hover {
+        border-color: var(--pal-border-secondary);
+      }
+    }
 
     svg {
       height: 1.5rem;
@@ -25,7 +33,7 @@
     }
   }
 
-  span {
+  &__label {
     font-size: 1rem;
     line-height: 1.5rem;
     color: var(--pal-text-primary);

--- a/src/components/WalletModalContent/index.tsx
+++ b/src/components/WalletModalContent/index.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Modal, TextLink } from "@stellar/design-system";
+import { wallets } from "constants/wallets";
+import { renderSvg } from "helpers/renderSvg";
+
+import "./styles.scss";
+
+interface WalletModalContentProps {
+  type: string;
+  buttonFooter?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const WalletModalContent: React.FC<WalletModalContentProps> = ({
+  type,
+  buttonFooter,
+  children,
+}) => {
+  const walletData = wallets[type];
+
+  if (!walletData) {
+    throw new Error(
+      "There is no Data for this wallet type. Please make sure the type is correct.",
+    );
+  }
+
+  const renderInfoLink = () => {
+    if (walletData.infoLink && walletData.infoLinkText) {
+      return (
+        <TextLink
+          href={walletData.infoLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {walletData.infoLinkText}
+        </TextLink>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <>
+      <div className="WalletModalContent__heading">
+        <div className="WalletModalContent__heading__logo">
+          {renderSvg({
+            Component: walletData.logoSvg,
+            alt: walletData.logoImgAltText,
+          })}
+        </div>
+      </div>
+      <Modal.Heading>{walletData.title}</Modal.Heading>
+
+      <Modal.Body>
+        <p className="align--center">
+          {walletData.infoText} {renderInfoLink()}
+        </p>
+        {children}
+      </Modal.Body>
+
+      {buttonFooter && <Modal.Footer>{buttonFooter}</Modal.Footer>}
+    </>
+  );
+};

--- a/src/components/WalletModalContent/styles.scss
+++ b/src/components/WalletModalContent/styles.scss
@@ -1,0 +1,21 @@
+.WalletModalContent {
+  &__heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    &__logo {
+      width: 3rem;
+      height: 3rem;
+      margin-bottom: 1rem;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      svg {
+        height: 100%;
+        fill: var(--pal-text-primary);
+      }
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -51,3 +51,21 @@
   margin-top: 2.5rem !important;
   margin-bottom: 2rem !important;
 }
+
+.Tooltip {
+  padding: 0.5rem 1rem;
+  background-color: var(--pal-brand-primary);
+  position: absolute;
+  max-width: 16.875rem;
+  border-radius: 0.125rem;
+  color: var(--pal-brand-primary-on);
+  font-size: var(--font-size-secondary);
+  line-height: 1.5em;
+  z-index: var(--z-index-tooltip);
+  cursor: default;
+
+  a {
+    color: inherit;
+    white-space: nowrap;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,8 @@
+// Generic styles
+.align--center {
+  text-align: center;
+}
+
 .Landing-container {
   padding-top: 4rem;
   display: flex;


### PR DESCRIPTION
This PR should have the dark mode fully supported on the landing page.

📓 I noticed that we are a bit inconsistent in how we display information in wallet modals. In some cases, we hide the connect button and info message if there is an error, and in others, we don't. I think we should make it consistent one way or another.

Tooltip support is not ideal, but we'll need to spend more time to make it more generic and easier to be used in various scenarios. This version is just to make it work for AV, we'll make it better when it's added to SDS.