### PR TITLE
Update deps action: change frequency to every other month + remove board

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -1,8 +1,8 @@
 name: Monthly dependency updates
 on:
   schedule:
-    # First of every month
-    - cron: 0 0 1 * *
+    # First of every other month
+    - cron: 0 0 1 */2 *
 
 jobs:
   create_issue:
@@ -23,9 +23,6 @@ jobs:
             Make sure there are no issues in the code editor, code compiles, and it runs without issues in the browser.
           pinned: false
           close-previous: true
-          project-type: organization
-          project: 21
-          column: Backlog
           labels: "account-viewer-v2, dependencies"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Updating dependencies every month is too often, so we're changing it to every other month.
- Last month's experiment with adding the issue to the board didn't work, so removed that part.