### PR TITLE
feat: replace WebUSB with WebHID for Ledger wallet connectivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@albedo-link/intent": "^0.12.0",
     "@ledgerhq/hw-app-str": "^6.27.16",
-    "@ledgerhq/hw-transport-webusb": "^6.27.16",
+    "@ledgerhq/hw-transport-webhid": "^6.27.16",
     "@reduxjs/toolkit": "^1.9.5",
     "@stellar/design-system": "^0.6.0",
     "@stellar/freighter-api": "^1.5.1",
@@ -83,8 +83,6 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/amplitude-js": "^8.16.2",
     "@types/jest": "^29.5.2",
-    "@types/ledgerhq__hw-transport-u2f": "^4.21.1",
-    "@types/ledgerhq__hw-transport-webusb": "^4.70.1",
     "@types/lodash": "^4.17.5",
     "@types/node": "^20.14.2",
     "@types/qrcode.react": "^1.0.2",

--- a/src/components/SignIn/SignInLedgerForm.tsx
+++ b/src/components/SignIn/SignInLedgerForm.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { styled } from "styled-components";
 import { Button, InfoBlock, Loader, TextLink } from "@stellar/design-system";
 import { getCatchError } from "@stellar/frontend-helpers";
-import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 
 import { BipPathInput } from "components/BipPathInput";
 import { ErrorMessage } from "components/ErrorMessage";
@@ -126,13 +126,13 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
   const handleConnect = async () => {
     setErrorMessage("");
     try {
-      const transport = await TransportWebUSB.request();
+      const transport = await TransportWebHID.request();
       dispatch(fetchLedgerStellarAddressAction({ ledgerBipPath, transport }));
     } catch (e) {
       const error = getCatchError(e);
       const message =
-        error.message === "navigator.usb is undefined"
-          ? "Your browser does not support WebUSB"
+        error.message === "navigator.hid is not supported"
+          ? "Your browser does not support WebHID"
           : error.toString();
 
       setErrorMessage(message);
@@ -158,10 +158,10 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
             application open on it.
           </p>
           <p>
-            Ledger Wallet is using WebUSB to communicate with hardware wallets,
+            Ledger Wallet is using WebHID to communicate with hardware wallets,
             check if your browser supports it{" "}
             <TextLink
-              href="https://caniuse.com/webusb"
+              href="https://caniuse.com/webhid"
               target="_blank"
               rel="noreferrer"
             >

--- a/src/components/SignIn/SignInLedgerForm.tsx
+++ b/src/components/SignIn/SignInLedgerForm.tsx
@@ -126,6 +126,16 @@ export const SignInLedgerForm = ({ onClose }: ModalPageProps) => {
   const handleConnect = async () => {
     setErrorMessage("");
     try {
+      // Close existing connections to avoid "device already open" error
+      const existingTransports = await TransportWebHID.list();
+      await Promise.all(
+        existingTransports.map((existingTransport) =>
+          existingTransport.close().catch(() => {
+            // Ignore close errors - device might already be closed
+          }),
+        ),
+      );
+
       const transport = await TransportWebHID.request();
       dispatch(fetchLedgerStellarAddressAction({ ledgerBipPath, transport }));
     } catch (e) {

--- a/src/ducks/wallet/ledger.ts
+++ b/src/ducks/wallet/ledger.ts
@@ -1,12 +1,12 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import LedgerApi from "@ledgerhq/hw-app-str";
-import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import { getCatchError } from "@stellar/frontend-helpers";
 import { ActionStatus, RejectMessage, WalletInitialState } from "types/types";
 
 export const fetchLedgerStellarAddressAction = createAsyncThunk<
   { publicKey: string; bipPath: string },
-  { ledgerBipPath: string; transport: TransportWebUSB },
+  { ledgerBipPath: string; transport: TransportWebHID },
   { rejectValue: RejectMessage }
 >(
   "walletLedger/fetchLedgerStellarAddressAction",

--- a/src/helpers/signLedgerTransaction.ts
+++ b/src/helpers/signLedgerTransaction.ts
@@ -7,6 +7,16 @@ export const signLedgerTransaction = async (
   publicKey: string,
   bipPath: string,
 ) => {
+  // Close existing connections to avoid "device already open" error
+  const existingTransports = await TransportWebHID.list();
+  await Promise.all(
+    existingTransports.map((existingTransport) =>
+      existingTransport.close().catch(() => {
+        // Ignore close errors - device might already be closed
+      }),
+    ),
+  );
+
   const transport = await TransportWebHID.create();
   const ledgerApi = new LedgerApi(transport);
   const result = await ledgerApi.signTransaction(

--- a/src/helpers/signLedgerTransaction.ts
+++ b/src/helpers/signLedgerTransaction.ts
@@ -1,5 +1,5 @@
 import { Keypair, Transaction, xdr } from "@stellar/stellar-sdk";
-import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import LedgerApi from "@ledgerhq/hw-app-str";
 
 export const signLedgerTransaction = async (
@@ -7,7 +7,7 @@ export const signLedgerTransaction = async (
   publicKey: string,
   bipPath: string,
 ) => {
-  const transport = await TransportWebUSB.create();
+  const transport = await TransportWebHID.create();
   const ledgerApi = new LedgerApi(transport);
   const result = await ledgerApi.signTransaction(
     bipPath,

--- a/src/helpers/submitPaymentTransaction.ts
+++ b/src/helpers/submitPaymentTransaction.ts
@@ -22,6 +22,12 @@ export const submitPaymentTransaction = async (transaction: Transaction) => {
     // HTTPS."
     // So we need to trigger the signing "directly" from the action, passing it
     // to the `wallet-sdk` fails because it's going through different layers.
+    //
+    // With the latest OS update of the Ledger Stax (1.8.0),
+    // Ledger Flex (1.4.0), Ledger Nano X (2.5.0) and
+    // Ledger Nano S Plus (1.4.0), Windows users cannot
+    // connect via WebUSB to third-party wallets.
+    // https://support.ledger.com/article/Windows-Cannot-connect-via-WebUSB
     if (settings.authType === AuthType.LEDGER) {
       if (walletLedger.data?.publicKey && walletLedger.data?.bipPath) {
         signedTransaction = await signLedgerTransaction(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,6 +2613,16 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@ledgerhq/devices@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-8.5.1.tgz#fed2960430ebab459211b692e1ecdc8c1dd04fe2"
+  integrity sha512-oW75YQQiP2muHveXTuwSAze6CBxJ7jOYILhFiJbsVzmgLPVqtdw4s0bJJlOBft4Aup67yNAjboFCIU7kTYQBFg==
+  dependencies:
+    "@ledgerhq/errors" "^6.25.0"
+    "@ledgerhq/logs" "^6.13.0"
+    rxjs "^7.8.1"
+    semver "^7.3.5"
+
 "@ledgerhq/devices@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.51.1.tgz#d741a4a5d8f17c2f9d282fd27147e6fe1999edb7"
@@ -2643,6 +2653,11 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.16.4.tgz#a38baffe8b096d9fff3ad839cadb55704c8d8e7b"
   integrity sha512-M57yFaLYSN+fZCX0E0zUqOmrV6eipK+s5RhijHoUNlHUqrsvUz7iRQgpd5gRgHB5VkIjav7KdaZjKiWGcHovaQ==
 
+"@ledgerhq/errors@^6.25.0":
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.25.0.tgz#1fa7ffa2038d0d1911c337804ea42b9430d80c34"
+  integrity sha512-9cU0dgUyq3Adb1bHAjJnbwl+r+4WBjuPq0k+/DbBNpuYHwcz2xKtRIjLimUJyACjHti3iWwRt1sFcbQDDdI08w==
+
 "@ledgerhq/hw-app-str@^6.27.16", "@ledgerhq/hw-app-str@^6.28.4":
   version "6.28.6"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-str/-/hw-app-str-6.28.6.tgz#1d2562b75e4cb8ffa14441323fad21589e2e4bce"
@@ -2663,15 +2678,15 @@
     "@ledgerhq/logs" "^5.30.0"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport-webusb@^6.27.16":
-  version "6.28.6"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.28.6.tgz#c17c193578da112ef76769e4ce72129d40d87faa"
-  integrity sha512-rzICsvhcFcL4wSAvRPe+b9EEWB8cxj6yWy3FZdfs7ufi/0muNpFXWckWv1TC34em55sGXu2cMcwMKXg/O/Lc0Q==
+"@ledgerhq/hw-transport-webhid@^6.27.16":
+  version "6.30.6"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.30.6.tgz#71886709477b2c995f201c99dc9549804ec98e26"
+  integrity sha512-AOzjFv5n1OTMfvEInAZRfLO11G5zfG8pB5zhmjK5d/mVQfFNcKsLZNAC2h4OZZMBtUy8UTT3n03z93e6k6n4pQ==
   dependencies:
-    "@ledgerhq/devices" "^8.3.0"
-    "@ledgerhq/errors" "^6.16.4"
-    "@ledgerhq/hw-transport" "^6.30.6"
-    "@ledgerhq/logs" "^6.12.0"
+    "@ledgerhq/devices" "8.5.1"
+    "@ledgerhq/errors" "^6.25.0"
+    "@ledgerhq/hw-transport" "^6.31.10"
+    "@ledgerhq/logs" "^6.13.0"
 
 "@ledgerhq/hw-transport@^5.34.0":
   version "5.51.1"
@@ -2692,6 +2707,16 @@
     "@ledgerhq/logs" "^6.12.0"
     events "^3.3.0"
 
+"@ledgerhq/hw-transport@^6.31.10":
+  version "6.31.10"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-6.31.10.tgz#be3c8b929b6a983e3ffb5821be6a44af074d701f"
+  integrity sha512-ruNtkTPMO3rFCaSM+oPTOXXerzxWFZF43pAHVAHhsjiQGhLWzLSkMc7qBEpWIpZPubKRAbWSXR2zXBIJPNy8oQ==
+  dependencies:
+    "@ledgerhq/devices" "8.5.1"
+    "@ledgerhq/errors" "^6.25.0"
+    "@ledgerhq/logs" "^6.13.0"
+    events "^3.3.0"
+
 "@ledgerhq/logs@^5.30.0", "@ledgerhq/logs@^5.50.0":
   version "5.50.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
@@ -2701,6 +2726,11 @@
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.12.0.tgz#ad903528bf3687a44da435d7b2479d724d374f5d"
   integrity sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==
+
+"@ledgerhq/logs@^6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.13.0.tgz#0b083af64b6b85db0630c7b940a0ed74ff6262b6"
+  integrity sha512-4+qRW2Pc8V+btL0QEmdB2X+uyx0kOWMWE1/LWsq5sZy3Q5tpi4eItJS6mB0XL3wGW59RQ+8bchNQQ1OW/va8Og==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
@@ -4057,29 +4087,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
-
-"@types/ledgerhq__hw-transport-u2f@^4.21.1":
-  version "4.21.4"
-  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport-u2f/-/ledgerhq__hw-transport-u2f-4.21.4.tgz#ca732fca898ff1c795bd2231366bd5fa2fd41465"
-  integrity sha512-srhlS//At7dpqGq/2Onr4q284LkPLfUYXsdD39/gqViXCasJREVkcV7Ux/gvLblSfOGO7glFejCH28oFrhgFPw==
-  dependencies:
-    "@types/ledgerhq__hw-transport" "*"
-    "@types/node" "*"
-
-"@types/ledgerhq__hw-transport-webusb@^4.70.1":
-  version "4.70.4"
-  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport-webusb/-/ledgerhq__hw-transport-webusb-4.70.4.tgz#8e1523afff30252a5b9823ea48e3607fbb394c65"
-  integrity sha512-k5mBuAPkhS/DvPkPlaCgHl4zSkOJqMG9htBQ21lggm5IhEwraUuDj0/pYIhA1E9CuquoZ/TEj09s/Jnwt5nU4A==
-  dependencies:
-    "@types/ledgerhq__hw-transport" "*"
-    "@types/node" "*"
-
-"@types/ledgerhq__hw-transport@*":
-  version "4.21.8"
-  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport/-/ledgerhq__hw-transport-4.21.8.tgz#973fedb76ade14307fe85db336373a5a5da54f79"
-  integrity sha512-uO2AJYZUVCwgyqgyy2/KW+JsQaO0hcwDdubRaHgF2ehO0ngGAY41PbE8qnPnmUw1uerMXONvL68QFioA7Y6C5g==
-  dependencies:
-    "@types/node" "*"
 
 "@types/lodash@^4.14.136":
   version "4.17.1"


### PR DESCRIPTION
Due to the latest Ledger firmware causing Ledger devices to be unable to connect via WebUSB on Windows, let's switch to WebHID to resolve this issue.

See https://support.ledger.com/article/Windows-Cannot-connect-via-WebUSB